### PR TITLE
Clean up dockerfile apt-gets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:latest
 
-RUN apt-get update && apt-get install -y curl gnupg
+RUN apt-get update && apt-get install -y curl gnupg && apt-get clean
 RUN curl -o- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
   apt-get update && apt-get install -y build-essential python curl git google-chrome-stable && apt-get clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM debian:latest
 
-RUN apt-get update && apt-get install -y build-essential python curl git && apt-get clean
-RUN \
-  curl -o- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+RUN apt-get update && apt-get install -y curl gnupg
+RUN curl -o- https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
   echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list && \
-  apt-get update && \
-  apt-get install -y google-chrome-stable
-RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash
-RUN bash -c 'NVM_DIR="/root/.nvm"; . "$NVM_DIR/nvm.sh"; nvm install 8.5.0;'
+  apt-get update && apt-get install -y build-essential python curl git google-chrome-stable && apt-get clean
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash && \
+  bash -c 'NVM_DIR="/root/.nvm"; . "$NVM_DIR/nvm.sh"; nvm install 8.5.0;'
 ENV PATH $PATH:/root/.nvm/versions/node/v8.5.0/bin/
 ADD . /root/zeo
 RUN bash -c 'cd /root/zeo && npm install --unsafe-perm'


### PR DESCRIPTION
@PeteBoucher is this in line with your thinking?

The main change here is to clean up after the installs, for less bloat in the images.

I couldn't actually manage to get it down to a single `install` though, since we don't have `curl`/`wget` or GPG to get the Chrome keys until we install it in the first place. :/